### PR TITLE
feat: renew session on user fetch

### DIFF
--- a/infra/controller.ts
+++ b/infra/controller.ts
@@ -1,4 +1,7 @@
+import type { H3Event } from "h3";
 import type { NuxtConnectHandlerOptions } from "~/libs/nuxt-connect";
+import { serverEnv } from "~/config/server-env";
+import session from "~/models/session";
 import {
   InternalServerError,
   ServiceError,
@@ -7,6 +10,15 @@ import {
   NotFoundError,
   UnauthorizedError,
 } from "./errors";
+
+function setSessionIdCookie(event: H3Event, sessionToken: string) {
+  setCookie(event, "session_id", sessionToken, {
+    path: "/",
+    maxAge: session.EXPIRATION_DATE_IN_SECONDS,
+    httpOnly: true,
+    secure: serverEnv.Mode === "production",
+  });
+}
 
 const errorHandlers: NuxtConnectHandlerOptions = {
   onNoMatch(event) {
@@ -24,6 +36,7 @@ const errorHandlers: NuxtConnectHandlerOptions = {
       return error.toJSON();
     }
     if (error instanceof UnauthorizedError) {
+      deleteCookie(event, "session_id");
       setResponseStatus(event, error.statusCode);
       return error.toJSON();
     }
@@ -38,4 +51,4 @@ const errorHandlers: NuxtConnectHandlerOptions = {
   },
 };
 
-export default { errorHandlers };
+export default { errorHandlers, setSessionIdCookie };

--- a/models/session.ts
+++ b/models/session.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import database from "~/infra/database";
-import { NotFoundError } from "~/infra/errors";
+import { UnauthorizedError } from "~/infra/errors";
 
 export type PublicSession = {
   id: string;
@@ -13,7 +13,7 @@ export type PublicSession = {
 
 const EXPIRATION_DATE_IN_SECONDS = 60 * 60 * 24 * 30;
 
-const genericSessionError = new NotFoundError(
+const unauthorizedSessionError = new UnauthorizedError(
   "Sessão não encontrada.",
   "Verifique se você está realmente logado e se a sessão existe.",
 );
@@ -30,31 +30,54 @@ async function create(userId: string) {
 }
 
 async function findValidByToken(token?: string) {
-  if (!token) throw genericSessionError;
+  if (!token) throw unauthorizedSessionError;
   const sessionRow = await database.sql`
     SELECT * FROM sessions
-    WHERE token = ${token};
+    WHERE token = ${token}
+    LIMIT 1;
   `;
-  if (!sessionRow.rowCount) throw genericSessionError;
-  let validSession: PublicSession | undefined;
-  for (const session of sessionRow.rows) {
-    if (new Date(session.expires_at) > new Date() && !validSession) {
-      validSession = session;
-      continue;
-    }
-    await remove(session.token);
+  if (!sessionRow.rowCount) throw unauthorizedSessionError;
+  const foundSession = sessionRow.rows[0] as PublicSession;
+  if (new Date(foundSession.expires_at) <= new Date()) {
+    await deleteByToken(foundSession.token);
+    throw unauthorizedSessionError;
   }
-  if (!validSession) throw genericSessionError;
-  return validSession;
+  return foundSession;
+}
+
+async function renew(sessionId: string) {
+  const date = addExpirationDate(new Date());
+  const sessionRow = await database.sql`
+    UPDATE sessions
+    SET
+      expires_at = ${date},
+      updated_at = timezone('utc', now())
+    WHERE id = ${sessionId}
+    RETURNING *;
+  `;
+  if (!sessionRow.rowCount) throw unauthorizedSessionError;
+  return sessionRow.rows[0] as PublicSession;
 }
 
 async function remove(sessionId?: string) {
-  if (!sessionId) throw genericSessionError;
+  if (!sessionId) throw unauthorizedSessionError;
   const sessionRow = await database.sql`
     DELETE FROM sessions
-    WHERE token = ${sessionId};
+    WHERE token = ${sessionId}
+    RETURNING *;
   `;
-  if (!sessionRow.rowCount) throw genericSessionError;
+  if (!sessionRow.rowCount) throw unauthorizedSessionError;
+  const removedSession = sessionRow.rows[0] as PublicSession;
+  if (new Date(removedSession.expires_at) <= new Date()) {
+    throw unauthorizedSessionError;
+  }
+}
+
+async function deleteByToken(token: string) {
+  await database.sql`
+    DELETE FROM sessions
+    WHERE token = ${token};
+  `;
 }
 
 function addExpirationDate(date: Date) {
@@ -65,6 +88,7 @@ function addExpirationDate(date: Date) {
 export default {
   create,
   remove,
+  renew,
   findValidByToken,
   addExpirationDate,
   EXPIRATION_DATE_IN_SECONDS,

--- a/server/api/v1/sessions/index.ts
+++ b/server/api/v1/sessions/index.ts
@@ -2,7 +2,6 @@ import { createNuxtRouter } from "~/libs/nuxt-connect";
 import controller from "~/infra/controller";
 import session from "~/models/session";
 import authentication from "~/models/authentication";
-import { serverEnv } from "~/config/server-env";
 
 const router = createNuxtRouter();
 
@@ -10,12 +9,7 @@ router.post(async (event) => {
   const body = await readBody(event);
   const user = await authentication.getAuthenticatedUser(body);
   const createdSession = await session.create(user.id);
-  setCookie(event, "session_id", createdSession.token, {
-    path: "/",
-    maxAge: session.EXPIRATION_DATE_IN_SECONDS,
-    httpOnly: true,
-    secure: serverEnv.Mode === "production",
-  });
+  controller.setSessionIdCookie(event, createdSession.token);
   setResponseStatus(event, 201);
   return createdSession;
 });

--- a/server/api/v1/users/index.ts
+++ b/server/api/v1/users/index.ts
@@ -6,8 +6,15 @@ import session from "~/models/session";
 const router = createNuxtRouter();
 
 router.get(async (event) => {
+  setResponseHeader(
+    event,
+    "Cache-Control",
+    "no-store, no-cache, max-age=0, must-revalidate",
+  );
   const sessionId = getCookie(event, "session_id");
   const publicSession = await session.findValidByToken(sessionId);
+  await session.renew(publicSession.id);
+  controller.setSessionIdCookie(event, publicSession.token);
   const userData = await user.findById(publicSession.user_id);
   return userData;
 });

--- a/tests/api/v1/sessions/delete.test.ts
+++ b/tests/api/v1/sessions/delete.test.ts
@@ -1,9 +1,10 @@
 import orquestrator from "~/infra/orquestrator";
+import session from "~/models/session";
 
 describe("delete /api/v1/sessions", () => {
-  const genericSessionError = {
-    status_code: 404,
-    name: "NotFoundError",
+  const unauthorizedSessionError = {
+    status_code: 401,
+    name: "UnauthorizedError",
     action: "Verifique se você está realmente logado e se a sessão existe.",
     message: "Sessão não encontrada.",
   };
@@ -17,15 +18,17 @@ describe("delete /api/v1/sessions", () => {
     test("Trying to delete unexisting session should never work", async () => {
       response = await getResponse();
       body = await response.json();
-      expect(response.status).toBe(404);
-      expect(body).toEqual(genericSessionError);
+      expect(response.status).toBe(401);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
     });
     test("Deleting a non existing session should not work", async () => {
       await orquestrator.createUser();
       response = await getResponse("invalid-session-id");
       body = await response.json();
-      expect(response.status).toBe(404);
-      expect(body).toEqual(genericSessionError);
+      expect(response.status).toBe(401);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
     });
   });
   describe("Existing user", () => {
@@ -47,11 +50,37 @@ describe("delete /api/v1/sessions", () => {
       await getResponse(createdSession.token);
       response = await getResponse(createdSession.token);
       body = await response.json();
-      expect(response.status).toBe(404);
-      expect(body).toEqual(genericSessionError);
+      expect(response.status).toBe(401);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
+    });
+    test("Deleting an expired session should not work", async () => {
+      const expiredNow = new Date();
+      expiredNow.setSeconds(
+        expiredNow.getSeconds() - session.EXPIRATION_DATE_IN_SECONDS - 1,
+      );
+      vi.useFakeTimers({ now: expiredNow });
+      const user = await orquestrator.createUser();
+      const createdSession = await orquestrator.createSession(user.id);
+      vi.useRealTimers();
+
+      response = await getResponse(createdSession.token);
+      body = await response.json();
+      expect(response.status).toBe(401);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
     });
   });
 });
+
+function expectSessionCookieToBeRemoved(response: Response) {
+  const cookies = response.headers.getSetCookie();
+  const isSessionCookieRemoved = cookies.some(
+    (cookie) =>
+      cookie.startsWith("session_id=") && cookie.includes("Max-Age=0"),
+  );
+  expect(isSessionCookieRemoved).toBe(true);
+}
 
 async function getResponse(sessionId?: string) {
   const headers: HeadersInit = {};

--- a/tests/api/v1/sessions/post.test.ts
+++ b/tests/api/v1/sessions/post.test.ts
@@ -19,6 +19,7 @@ describe("post /api/v1/sessions", () => {
       expect(body.name).toBe("UnauthorizedError");
       expect(body.message).toBe("Os dados de autenticação não conferem.");
       expect(body.action).toBe("Por favor revise os dados e tente novamente.");
+      expectSessionCookieToBeRemoved(response);
     });
     test("with wrong password", async () => {
       const user = await orquestrator.createUser();
@@ -31,6 +32,7 @@ describe("post /api/v1/sessions", () => {
       expect(body.name).toBe("UnauthorizedError");
       expect(body.message).toBe("Os dados de autenticação não conferem.");
       expect(body.action).toBe("Por favor revise os dados e tente novamente.");
+      expectSessionCookieToBeRemoved(response);
     });
     test("with correct password", async () => {
       const user = await orquestrator.createUser({ password: "somePassword" });
@@ -58,8 +60,47 @@ describe("post /api/v1/sessions", () => {
       createdAt.setMilliseconds(0);
       expect(session.addExpirationDate(createdAt)).toStrictEqual(expiresAt);
     });
+    test("with correct password should allow multiple active sessions for the same user", async () => {
+      const user = await orquestrator.createUser({ password: "somePassword" });
+      const firstLoginResponse = await getResponse({
+        email: user.email,
+        password: "somePassword",
+      });
+      const firstLoginBody = await firstLoginResponse.json();
+      const secondLoginResponse = await getResponse({
+        email: user.email,
+        password: "somePassword",
+      });
+      const secondLoginBody = await secondLoginResponse.json();
+      expect(firstLoginResponse.status).toBe(201);
+      expect(secondLoginResponse.status).toBe(201);
+      expect(firstLoginBody.user_id).toBe(user.id);
+      expect(secondLoginBody.user_id).toBe(user.id);
+      expect(firstLoginBody.token).not.toBe(secondLoginBody.token);
+      const firstSessionUserResponse = await getAuthenticatedUserResponse(
+        firstLoginBody.token,
+      );
+      const firstSessionUserBody = await firstSessionUserResponse.json();
+      const secondSessionUserResponse = await getAuthenticatedUserResponse(
+        secondLoginBody.token,
+      );
+      const secondSessionUserBody = await secondSessionUserResponse.json();
+      expect(firstSessionUserResponse.status).toBe(200);
+      expect(secondSessionUserResponse.status).toBe(200);
+      expect(firstSessionUserBody.id).toBe(user.id);
+      expect(secondSessionUserBody.id).toBe(user.id);
+    });
   });
 });
+
+function expectSessionCookieToBeRemoved(response: Response) {
+  const cookies = response.headers.getSetCookie();
+  const isSessionCookieRemoved = cookies.some(
+    (cookie) =>
+      cookie.startsWith("session_id=") && cookie.includes("Max-Age=0"),
+  );
+  expect(isSessionCookieRemoved).toBe(true);
+}
 
 async function getResponse(user: any) {
   return fetch("http://localhost:3000/api/v1/sessions", {
@@ -68,5 +109,11 @@ async function getResponse(user: any) {
     headers: {
       "Content-Type": "application/json",
     },
+  });
+}
+
+async function getAuthenticatedUserResponse(sessionId: string) {
+  return fetch("http://localhost:3000/api/v1/users", {
+    headers: { Cookie: `session_id=${sessionId}` },
   });
 }

--- a/tests/api/v1/users/get.test.ts
+++ b/tests/api/v1/users/get.test.ts
@@ -2,9 +2,10 @@ import orquestrator from "~/infra/orquestrator";
 import session from "~/models/session";
 
 describe("get /api/v1/users", () => {
-  const genericSessionError = {
-    status_code: 404,
-    name: "NotFoundError",
+  const nonCacheableHeader = "no-store, no-cache, max-age=0, must-revalidate";
+  const unauthorizedSessionError = {
+    status_code: 401,
+    name: "UnauthorizedError",
     action: "Verifique se você está realmente logado e se a sessão existe.",
     message: "Sessão não encontrada.",
   };
@@ -21,14 +22,18 @@ describe("get /api/v1/users", () => {
     test("Trying to fetch an user without session_id should not work", async () => {
       response = await getResponse();
       body = await response.json();
-      expect(response.status).toBe(404);
-      expect(body).toEqual(genericSessionError);
+      expect(response.status).toBe(401);
+      expect(response.headers.get("Cache-Control")).toBe(nonCacheableHeader);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
     });
     test("Trying to fetch an user with wrong session_id should not work", async () => {
       response = await getResponse("wrong-session-id");
       body = await response.json();
-      expect(response.status).toBe(404);
-      expect(body).toEqual(genericSessionError);
+      expect(response.status).toBe(401);
+      expect(response.headers.get("Cache-Control")).toBe(nonCacheableHeader);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
     });
   });
   describe("Existing user", () => {
@@ -37,14 +42,15 @@ describe("get /api/v1/users", () => {
       expiredNow.setSeconds(
         expiredNow.getSeconds() - session.EXPIRATION_DATE_IN_SECONDS - 1,
       );
-      vi.useFakeTimers({ now: expiredNow, toFake: ["Date"] });
+      vi.useFakeTimers({ now: expiredNow });
       const user = await orquestrator.createUser();
       const createdSession = await orquestrator.createSession(user.id);
       vi.useRealTimers();
       response = await getResponse(createdSession.token);
       body = await response.json();
-      expect(response.status).toBe(404);
-      expect(body).toEqual(genericSessionError);
+      expect(response.status).toBe(401);
+      expect(body).toEqual(unauthorizedSessionError);
+      expectSessionCookieToBeRemoved(response);
     });
     test("Trying to fetch an user with correct session_id should work", async () => {
       const user = await orquestrator.createUser();
@@ -52,6 +58,7 @@ describe("get /api/v1/users", () => {
       response = await getResponse(createdSession.token);
       body = await response.json();
       expect(response.status).toBe(200);
+      expect(response.headers.get("Cache-Control")).toBe(nonCacheableHeader);
       expect(body).toEqual({
         id: user.id,
         username: user.username,
@@ -61,8 +68,37 @@ describe("get /api/v1/users", () => {
         updated_at: user.updated_at.toISOString(),
       });
     });
+    test("Trying to fetch an user with correct session_id should renew expires_at", async () => {
+      const almostExpired = new Date();
+      almostExpired.setDate(almostExpired.getDate() - 29);
+      vi.useFakeTimers({ now: almostExpired });
+      const user = await orquestrator.createUser();
+      const createdSession = await orquestrator.createSession(user.id);
+      vi.useRealTimers();
+      response = await getResponse(createdSession.token);
+      body = await response.json();
+      const cookies = response.headers.getSetCookie();
+      expect(response.status).toBe(200);
+      expect(body.id).toBe(user.id);
+      const isRenewedCookie = cookies.some(
+        (cookie) =>
+          cookie.includes(`session_id=${createdSession.token}`) &&
+          cookie.includes(`Max-Age=${session.EXPIRATION_DATE_IN_SECONDS}`) &&
+          cookie.includes("HttpOnly"),
+      );
+      expect(isRenewedCookie).toBe(true);
+    });
   });
 });
+
+function expectSessionCookieToBeRemoved(response: Response) {
+  const cookies = response.headers.getSetCookie();
+  const isSessionCookieRemoved = cookies.some(
+    (cookie) =>
+      cookie.startsWith("session_id=") && cookie.includes("Max-Age=0"),
+  );
+  expect(isSessionCookieRemoved).toBe(true);
+}
 
 async function getResponse(sessionId?: string) {
   return fetch("http://localhost:3000/api/v1/users", {


### PR DESCRIPTION
## Summary
- renew valid user sessions when fetching the authenticated user
- centralize session cookie creation in the controller helper
- cover renewed session cookie behavior in the users API test

## Tests
- commit script ran secretlint, prettier --check, eslint, and vitest: 12 files passed, 36 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions automatically renew when users access their account; multiple simultaneous sessions per user are supported.

* **Security**
  * Session cookies are HTTP-only and set to use Secure in production; cookie handling is centralized for consistent settings.

* **Bug Fixes**
  * Expired sessions are detected and treated as invalid (delete/404) to prevent reuse.

* **Tests**
  * Added/updated tests covering renewal, multiple sessions, expired-session deletion, and cookie headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->